### PR TITLE
Setup validation to only run on specific pull requests

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -1,5 +1,9 @@
 name: Push & PR Validation
-on: [ push, pull_request ]
+on: 
+  push:
+    branches-ignore: [master, staging]
+  pull_request:
+    branches: [master, staging]
 
 jobs:
   commitlint:


### PR DESCRIPTION
Previously, validation ran on all branches, for all pushes and pull requests. This change makes it so that validation only runs on **pushes** to branches other than `master` and `staging`, and additionally only runs validation on **PRs** on `master` and `staging`. This will stop the doubling up on validation tasks that we've been seeing.