### PR TITLE
Set `--first-parent` parameter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    
+    name: Run Semantic Release
     steps:
       - name: Checkout latest
         uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "test": "jest",
     "lint": "eslint .",
-    "release": "multi-semantic-release --debug"
+    "release": "multi-semantic-release --debug --first-parent"
   },
   "devDependencies": {
     "@amanda-mitchell/semantic-release-npm-multiple": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "test": "jest",
     "lint": "eslint .",
-    "release": "multi-semantic-release"
+    "release": "multi-semantic-release --debug"
   },
   "devDependencies": {
     "@amanda-mitchell/semantic-release-npm-multiple": "^2.4.0",


### PR DESCRIPTION
According to the docs for `multi-semantic-release`, it's implied that, but default, only the root branch is checked. This is not the desired behavior for functional-things, so we set `--first-parent`. This makes `multi-semantic-release` check the current branch.